### PR TITLE
Simplified launch file and fix for gripper droop

### DIFF
--- a/tn_locobot_control/launch/tn_locobot_control_basic.launch
+++ b/tn_locobot_control/launch/tn_locobot_control_basic.launch
@@ -1,0 +1,21 @@
+<!-- This launch file starts all of the robot/ simulation-side components
+    needed to control a locobot (Gazebo simulation) from a remote web interface -->
+
+<launch>
+    <arg name="use_base" default="true"/>
+    <arg name="use_arm" default="true"/>
+    <arg name="use_sim" default="true"/>
+    <arg name="use_camera" default="true"/>
+
+    <include file="$(find locobot_control)/launch/main.launch">
+        <arg name="use_base" value="$(arg use_base)"/>
+        <arg name="use_arm" value="$(arg use_arm)"/>
+        <arg name="use_sim" value="$(arg use_sim)"/>
+        <arg name="use_camera" value="$(arg use_camera)"/>
+    </include>
+
+    <node name="video_server" pkg="web_video_server" type="web_video_server" />
+    <node name="ros_to_flask_bridge" pkg="flask_bridge" type="ros_flask_bridge.py" />
+    <!-- <node name="locobot_gui_ctrl" pkg="tn_locobot_control" type="locobot_gui_control.py" output="screen"/> -->
+
+</launch>

--- a/tn_locobot_control/scripts/locobot_gui_control.py
+++ b/tn_locobot_control/scripts/locobot_gui_control.py
@@ -39,9 +39,20 @@ def xyzArmCallback(msg):
         rospy.loginfo("no arm movement requested")
     
     else:
+        # displacement = np.array([arm_x, arm_y, arm_z])
+        # success = robot.arm.move_ee_xyz(displacement, plan=False)
+        # rospy.loginfo("tried to move arm")
         displacement = np.array([arm_x, arm_y, arm_z])
-        success = robot.arm.move_ee_xyz(displacement, plan=False)
-        rospy.loginfo("tried to move arm")
+        t,r,q = robot.arm.pose_ee
+        translation = np.add(np.asarray(t).flatten(), displacement)
+        orientation = np.asarray(r)
+        ident = np.eye(3)
+        orientation[:,2] = ident[:,2]
+        orientation[2,:] = ident[2,:]
+        robot.arm.set_ee_pose(translation, orientation, plan=False)
+        rospy.loginfo("translation was %s", str(translation))
+        rospy.loginfo("orientation was %s", str(orientation))
+
  
 def twistCallback(msg):
     """


### PR DESCRIPTION
The new control code allows the gripper's orientation to drift about the z-axis but fixes it to the horizontal plane.  This should be sufficient until/unless we implement direct or autonomous gripper pose control.